### PR TITLE
fix: methods which will intecept by ownKeys should get the same resul…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Fix isOwnKeysChanged not check the value
 
 ## [2.0.3] - 2022-02-28
 ### Changed

--- a/__tests__/10_deep_proxy_spec.ts
+++ b/__tests__/10_deep_proxy_spec.ts
@@ -134,7 +134,7 @@ describe('keys spec', () => {
     const p1 = createProxy(s1, a1);
     noop(Object.keys(p1));
     expect(isChanged(s1, { a: s1.a, c: 'c' }, a1)).toBe(false);
-    expect(isChanged(s1, { a: { b: 'b' }, c: 'c' }, a1)).toBe(false);
+    expect(isChanged(s1, { a: { b: 'b' }, c: 'c' }, a1)).toBe(true);
     expect(isChanged(s1, { a: s1.a }, a1)).toBe(true);
     expect(isChanged(s1, { a: s1.a, c: 'c', d: 'd' }, a1)).toBe(true);
   });
@@ -148,7 +148,7 @@ describe('keys spec', () => {
       noop(k);
     }
     expect(isChanged(s1, { a: s1.a, c: 'c' }, a1)).toBe(false);
-    expect(isChanged(s1, { a: { b: 'b' }, c: 'c' }, a1)).toBe(false);
+    expect(isChanged(s1, { a: { b: 'b' }, c: 'c' }, a1)).toBe(true);
     expect(isChanged(s1, { a: s1.a }, a1)).toBe(true);
     expect(isChanged(s1, { a: s1.a, c: 'c', d: 'd' }, a1)).toBe(true);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,8 +182,19 @@ export const createProxy = <T>(
 const isOwnKeysChanged = (origObj: object, nextObj: object) => {
   const origKeys = Reflect.ownKeys(origObj);
   const nextKeys = Reflect.ownKeys(nextObj);
-  return origKeys.length !== nextKeys.length
+  const simpleCheckResult = origKeys.length !== nextKeys.length
     || origKeys.some((k, i) => k !== nextKeys[i]);
+
+  if (simpleCheckResult) {
+    return true;
+  }
+
+  const fakeAffected = new Map();
+  const used = new Set();
+  fakeAffected.set(origObj, used);
+  origKeys.forEach((k) => used.add(k));
+
+  return isChanged(origObj, nextObj, fakeAffected);
 };
 
 type ChangedCache = WeakMap<object, {


### PR DESCRIPTION
I think the APIs which will intercept by `ownKeys()` should get the same result as exhausting all properties.

For example:

```js
const s1 = { a: { b: 'b' }, c: 'c' };
const a1 = new WeakMap();
const p1 = createProxy(s1, a1);

p1.a;
p1.c;

isChanged(s1, { a: { b: 'b' }, c: 'c' }, a1); // true
```

should be the same as:

```js
const s1 = { a: { b: 'b' }, c: 'c' };
const a1 = new WeakMap();
const p1 = createProxy(s1, a1);

Object.keys(p1);

isChanged(s1, { a: { b: 'b' }, c: 'c' }, a1); // false, Ooops!
```


