### PR TITLE
chore: rename origObj to prevObj to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ on the proxy, then isChanged will only compare the affected properties.
 
 #### Parameters
 
-*   `origObj` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** The original object to compare.
-*   `nextObj` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Object to compare with the original one.
+*   `prevObj` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** The previous object to compare.
+*   `nextObj` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Object to compare with the previous one.
 *   `affected` **[WeakMap](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap)<[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object), unknown>** WeakMap that holds the tracking of which properties in the proxied object were accessed.
 *   `cache` **[WeakMap](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap)<[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object), unknown>?** WeakMap that holds a cache of the comparisons for better performance with repetitive comparisons,
     and to avoid infinite loop with circular structures.
@@ -109,18 +109,18 @@ on the proxy, then isChanged will only compare the affected properties.
 ```javascript
 import { createProxy, isChanged } from 'proxy-compare';
 
-const original = { a: "1", c: "2", d: { e: "3" } };
+const obj = { a: "1", c: "2", d: { e: "3" } };
 const affected = new WeakMap();
 
-const proxy = createProxy(original, affected);
+const proxy = createProxy(obj, affected);
 
 proxy.a
 
-isChanged(original, { a: "1" }, affected) // false
+isChanged(obj, { a: "1" }, affected) // false
 
 proxy.a = "2"
 
-isChanged(original, { a: "1" }, affected) // true
+isChanged(obj, { a: "1" }, affected) // true
 ```
 
 Returns **[boolean](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Boolean indicating if the affected property on the object has changed.
@@ -146,7 +146,7 @@ const affected = new WeakMap();
 const proxy = createProxy(original, affected);
 const originalFromProxy = getUntracked(proxy)
 
-Obejct.is(original, originalFromProxy) // true
+Object.is(original, originalFromProxy) // true
 isChanged(original, originalFromProxy, affected) // false
 ```
 
@@ -164,8 +164,7 @@ to be untracked when creating your proxy.
 #### Parameters
 
 *   `obj` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Object to mark as tracked or not.
-*   `mark`   (optional, default `true`)
-*   `boolean` **mark** Boolean indicating whether you want to track this object or not.
+*   `mark`  Boolean indicating whether you want to track this object or not. (optional, default `true`)
 
 #### Examples
 
@@ -186,7 +185,7 @@ proxy.d.e
 isChanged(original, { d: { e: "3" } }, affected) // true
 ```
 
-Returns **[undefined](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined)** No return.
+Returns **any** No return.
 
 ## Projects using this library
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,8 +209,8 @@ type ChangedCache = WeakMap<object, {
  * reference equality check for the objects provided (Object.is(a, b)). If you access a property
  * on the proxy, then isChanged will only compare the affected properties.
  *
- * @param {object} origObj - The original object to compare.
- * @param {object} nextObj - Object to compare with the original one.
+ * @param {object} prevObj - The previous object to compare.
+ * @param {object} nextObj - Object to compare with the previous one.
  * @param {WeakMap<object, unknown>} affected -
  * WeakMap that holds the tracking of which properties in the proxied object were accessed.
  * @param {WeakMap<object, unknown>} [cache] -
@@ -221,39 +221,39 @@ type ChangedCache = WeakMap<object, {
  * @example
  * import { createProxy, isChanged } from 'proxy-compare';
  *
- * const original = { a: "1", c: "2", d: { e: "3" } };
+ * const obj = { a: "1", c: "2", d: { e: "3" } };
  * const affected = new WeakMap();
  *
- * const proxy = createProxy(original, affected);
+ * const proxy = createProxy(obj, affected);
  *
  * proxy.a
  *
- * isChanged(original, { a: "1" }, affected) // false
+ * isChanged(obj, { a: "1" }, affected) // false
  *
  * proxy.a = "2"
  *
- * isChanged(original, { a: "1" }, affected) // true
+ * isChanged(obj, { a: "1" }, affected) // true
  */
 
 export const isChanged = (
-  origObj: unknown,
+  prevObj: unknown,
   nextObj: unknown,
   affected: WeakMap<object, unknown>,
   cache?: WeakMap<object, unknown>,
 ): boolean => {
-  if (Object.is(origObj, nextObj)) {
+  if (Object.is(prevObj, nextObj)) {
     return false;
   }
-  if (!isObject(origObj) || !isObject(nextObj)) return true;
-  const used = (affected as Affected).get(origObj);
+  if (!isObject(prevObj) || !isObject(nextObj)) return true;
+  const used = (affected as Affected).get(prevObj);
   if (!used) return true;
   if (cache) {
-    const hit = (cache as ChangedCache).get(origObj);
+    const hit = (cache as ChangedCache).get(prevObj);
     if (hit && hit[NEXT_OBJECT_PROPERTY] === nextObj) {
       return hit[CHANGED_PROPERTY];
     }
     // for object with cycles
-    (cache as ChangedCache).set(origObj, {
+    (cache as ChangedCache).set(prevObj, {
       [NEXT_OBJECT_PROPERTY]: nextObj,
       [CHANGED_PROPERTY]: false,
     });
@@ -261,9 +261,9 @@ export const isChanged = (
   let changed: boolean | null = null;
   // eslint-disable-next-line no-restricted-syntax
   for (const key of used) {
-    const c = key === OWN_KEYS_SYMBOL ? isOwnKeysChanged(origObj, nextObj)
+    const c = key === OWN_KEYS_SYMBOL ? isOwnKeysChanged(prevObj, nextObj)
       : isChanged(
-        (origObj as any)[key],
+        (prevObj as any)[key],
         (nextObj as any)[key],
         affected,
         cache,
@@ -273,7 +273,7 @@ export const isChanged = (
   }
   if (changed === null) changed = true;
   if (cache) {
-    cache.set(origObj, {
+    cache.set(prevObj, {
       [NEXT_OBJECT_PROPERTY]: nextObj,
       [CHANGED_PROPERTY]: changed,
     });
@@ -324,9 +324,9 @@ export const getUntracked = <T>(obj: T): T | null => {
  * so this is useful for example to mark a class instance to track or to mark a object
  * to be untracked when creating your proxy.
  *
- * @param {object} obj - Object to mark as tracked or not.
- * @param {mark} boolean - Boolean indicating whether you want to track this object or not.
- * @returns {undefined} - No return.
+ * @param obj - Object to mark as tracked or not.
+ * @param mark - Boolean indicating whether you want to track this object or not.
+ * @returns No return.
  *
  * @example
  * import { createProxy, markToTrack, isChanged } from 'proxy-compare';


### PR DESCRIPTION
Just changing a variable name and some docs.