### PR TITLE
fix: cache unfreeze results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Change
+- fix: cache unfreeze results #44
 
 ## [2.2.0] - 2022-06-14
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,16 +41,23 @@ const isFrozen = (obj: object) => (
 );
 
 // copy frozen object
+const unfrozenCache = new WeakMap<object, object>();
 const unfreeze = (obj: object) => {
-  if (Array.isArray(obj)) {
-    // Arrays need a special way to copy
-    return Array.from(obj);
+  let unfrozen = unfrozenCache.get(obj);
+  if (!unfrozen) {
+    if (Array.isArray(obj)) {
+      // Arrays need a special way to copy
+      unfrozen = Array.from(obj);
+    } else {
+      // For non-array objects, we create a new object keeping the prototype
+      // with changing all configurable options (otherwise, proxies will complain)
+      const descriptors = Object.getOwnPropertyDescriptors(obj);
+      Object.values(descriptors).forEach((desc) => { desc.configurable = true; });
+      unfrozen = Object.create(getProto(obj), descriptors);
+    }
+    unfrozenCache.set(obj, unfrozen as object);
   }
-  // For non-array objects, we create a new object keeping the prototype
-  // with changing all configurable options (otherwise, proxies will complain)
-  const descriptors = Object.getOwnPropertyDescriptors(obj);
-  Object.values(descriptors).forEach((desc) => { desc.configurable = true; });
-  return Object.create(getProto(obj), descriptors);
+  return unfrozen as object;
 };
 
 type Affected = WeakMap<object, Set<string | symbol>>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ export const createProxy = <T>(
     handlerAndState[1][PROXY_PROPERTY] = newProxy(
       frozen ? unfreeze(target) : target,
       handlerAndState[0],
-    );
+    ) as typeof target;
     if (proxyCache) {
       proxyCache.set(target, handlerAndState);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const isFrozen = (obj: object) => (
 
 // copy frozen object
 const unfrozenCache = new WeakMap<object, object>();
-const unfreeze = (obj: object) => {
+const unfreeze = <T extends object>(obj: T): T => {
   let unfrozen = unfrozenCache.get(obj);
   if (!unfrozen) {
     if (Array.isArray(obj)) {
@@ -63,7 +63,7 @@ const unfreeze = (obj: object) => {
     }
     unfrozenCache.set(obj, unfrozen as object);
   }
-  return unfrozen as object;
+  return unfrozen as T;
 };
 
 type Affected = WeakMap<object, Set<string | symbol>>;
@@ -194,7 +194,7 @@ export const createProxy = <T>(
     handlerAndState[1][PROXY_PROPERTY] = newProxy(
       frozen ? unfreeze(target) : target,
       handlerAndState[0],
-    ) as typeof target;
+    );
     if (proxyCache) {
       proxyCache.set(target, handlerAndState);
     }


### PR DESCRIPTION
We `unfreeze` a frozen object every time. This causes a performance bottleneck. https://github.com/pmndrs/valtio/issues/519
This PR fixes it by caching the results.