### PR TITLE
feat: better support of Object.hasOwn and "in"

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "buildCommand": "compile",
   "sandboxes": ["vanilla", "vanilla-typescript-vanilla-ts", "new", "react-typescript-react-ts"],
-  "node": "12"
+  "node": "14"
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,8 @@
     "no-multi-assign": "off",
     "no-nested-ternary": "off",
     "no-unused-vars": "off",
-    "@typescript-eslint/ban-types": "off"
+    "@typescript-eslint/ban-types": "off",
+    "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"]
   },
   "overrides": [{
     "files": ["__tests__/**/*"],

--- a/__tests__/10_deep_proxy_spec.ts
+++ b/__tests__/10_deep_proxy_spec.ts
@@ -137,6 +137,7 @@ describe('keys spec', () => {
     expect(isChanged(s1, { a: { b: 'b' }, c: 'c' }, a1)).toBe(false);
     expect(isChanged(s1, { a: s1.a }, a1)).toBe(true);
     expect(isChanged(s1, { a: s1.a, c: 'c', d: 'd' }, a1)).toBe(true);
+    expect(affectedToPathList(s1, a1)).toEqual([[':ownKeys']]);
   });
 
   it('for-in', () => {
@@ -160,22 +161,21 @@ describe('keys spec', () => {
     noop('a' in p1);
     expect(isChanged(s1, { a: s1.a, c: 'c' }, a1)).toBe(false);
     expect(isChanged(s1, { a: s1.a }, a1)).toBe(false);
+    expect(isChanged(s1, { a: null }, a1)).toBe(false);
     expect(isChanged(s1, { c: 'c', d: 'd' }, a1)).toBe(true);
+    expect(affectedToPathList(s1, a1)).toEqual([[':has(a)']]);
   });
 
   it('hasOwnProperty', () => {
     const s1 = { a: { b: 'b' }, c: 'c' };
     const a1 = new WeakMap();
     const p1 = createProxy(s1, a1);
-    // eslint-disable-next-line no-prototype-builtins
-    noop(p1.hasOwnProperty('a'));
+    noop(Object.prototype.hasOwnProperty.call(p1, 'a'));
     expect(isChanged(s1, { a: s1.a, c: 'c' }, a1)).toBe(false);
     expect(isChanged(s1, { a: s1.a }, a1)).toBe(false);
+    expect(isChanged(s1, { a: null, c: 'c' }, a1)).toBe(false);
     expect(isChanged(s1, { c: 'c', d: 'd' }, a1)).toBe(true);
-    // NOTE: due to the way this is implemented,
-    // changing the value of 'a' causes a change,
-    // even though we only used `hasOwnProperty` above.
-    expect(isChanged(s1, { a: null, c: 'c' }, a1)).toBe(true);
+    expect(affectedToPathList(s1, a1)).toEqual([[':hasOwn(a)']]);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,10 +9,10 @@ const PROXY_PROPERTY = 'p';
 const PROXY_CACHE_PROPERTY = 'c';
 const NEXT_OBJECT_PROPERTY = 'n';
 const CHANGED_PROPERTY = 'g';
-const KEYS_PROPERTY = 'k';
 const HAS_KEY_PROPERTY = 'h';
-const HAS_OWN_KEY_PROPERTY = 'o';
 const ALL_OWN_KEYS_PROPERTY = 'w';
+const HAS_OWN_KEY_PROPERTY = 'o';
+const KEYS_PROPERTY = 'k';
 
 // function to create a new bare proxy
 let newProxy = <T extends object>(
@@ -69,14 +69,14 @@ const unfreeze = <T extends object>(obj: T): T => {
   return unfrozen as T;
 };
 
-type KeysSet = Set<string | symbol>
 type HasKeySet = Set<string | symbol>
 type HasOwnKeySet = Set<string | symbol>
+type KeysSet = Set<string | symbol>
 type Used = {
-  [KEYS_PROPERTY]?: KeysSet;
   [HAS_KEY_PROPERTY]?: HasKeySet;
-  [HAS_OWN_KEY_PROPERTY]?: HasOwnKeySet;
   [ALL_OWN_KEYS_PROPERTY]?: true;
+  [HAS_OWN_KEY_PROPERTY]?: HasOwnKeySet;
+  [KEYS_PROPERTY]?: KeysSet;
 };
 type Affected = WeakMap<object, Used>;
 type ProxyHandlerState<T extends object> = {
@@ -97,10 +97,10 @@ const createProxyHandler = <T extends object>(origObj: T, frozen: boolean) => {
   let trackObject = false; // for trackMemo
   const recordUsage = (
     type:
-      | typeof KEYS_PROPERTY
       | typeof HAS_KEY_PROPERTY
+      | typeof ALL_OWN_KEYS_PROPERTY
       | typeof HAS_OWN_KEY_PROPERTY
-      | typeof ALL_OWN_KEYS_PROPERTY,
+      | typeof KEYS_PROPERTY,
     key?: string | symbol,
   ) => {
     if (!trackObject) {
@@ -147,7 +147,7 @@ const createProxyHandler = <T extends object>(origObj: T, frozen: boolean) => {
     },
     getOwnPropertyDescriptor(target, key) {
       recordUsage(HAS_OWN_KEY_PROPERTY, key);
-      return Object.getOwnPropertyDescriptor(target, key);
+      return Reflect.getOwnPropertyDescriptor(target, key);
     },
     ownKeys(target) {
       recordUsage(ALL_OWN_KEYS_PROPERTY);


### PR DESCRIPTION
Prior to this commit `Object.hasOwn` and `in` operator would mark object keys as tracked meaning that different values for the key would result in object being reported as changed even though the actual value was never read.

With this commit we start tracking `hasKey` and `hasOwnKey` separately from regular properties and check for the key presence/absence in `isChanged`.