### PR TITLE
fix: get method of proxy handlers will return the original value when target[key] is read-only and non-configurable

### DIFF
--- a/__tests__/20_immer_v8.ts
+++ b/__tests__/20_immer_v8.ts
@@ -17,7 +17,6 @@ describe('immer v8', () => {
     expect(isChanged(s1, { a: { b: 'b' } }, a1)).toBe(true);
     Object.freeze(s1.a);
     Object.freeze(s1);
-    noop(p1.a);
     const a2 = new WeakMap();
     const p2 = createProxy(s1, a2, proxyCache);
     noop(p2.a.b);
@@ -25,5 +24,20 @@ describe('immer v8', () => {
     expect(isChanged(s1, { a: s1.a }, a2)).toBe(false);
     expect(isChanged(s1, { a: { b: 'b' } }, a2)).toBe(false);
     expect(isChanged(s1, { a: { b: 'b2' } }, a2)).toBe(true);
+  });
+
+  // https://github.com/dai-shi/proxy-compare/pull/50
+  it('should work if object is frozen afterward 2', () => {
+    const proxyCache = new WeakMap();
+    const s1 = { a: { b: 'b' } };
+    const a1 = new WeakMap();
+    const p1 = createProxy(s1, a1, proxyCache);
+    Object.freeze(s1.a);
+    Object.freeze(s1);
+    noop(p1.a.b);
+    expect(isChanged(s1, s1, a1)).toBe(false);
+    expect(isChanged(s1, { a: s1.a }, a1)).toBe(false);
+    expect(isChanged(s1, { a: { b: 'b' } }, a1)).toBe(false);
+    expect(isChanged(s1, { a: { b: 'b2' } }, a1)).toBe(true);
   });
 });

--- a/__tests__/20_immer_v8.ts
+++ b/__tests__/20_immer_v8.ts
@@ -17,6 +17,7 @@ describe('immer v8', () => {
     expect(isChanged(s1, { a: { b: 'b' } }, a1)).toBe(true);
     Object.freeze(s1.a);
     Object.freeze(s1);
+    noop(p1.a);
     const a2 = new WeakMap();
     const p2 = createProxy(s1, a2, proxyCache);
     noop(p2.a.b);


### PR DESCRIPTION
fix: get method of proxy handlers will return the original value when target[key] is read-only and non-configurable